### PR TITLE
added an option to preserve the message order accoring to arrival time in TimedRebeca

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.rebecalang</groupId>
 	<artifactId>rmc</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.1-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/rebecalang/rmc/AnalysisFeature.java
+++ b/src/main/java/org/rebecalang/rmc/AnalysisFeature.java
@@ -2,7 +2,7 @@ package org.rebecalang.rmc;
 
 public enum AnalysisFeature {
 	//General
-	TRACE_GENERATOR, DEBUG, DEBUG_LEVEL_2, EXPORT_STATE_SPACE,
+	TRACE_GENERATOR, DEBUG, DEBUG_LEVEL_2, EXPORT_STATE_SPACE, PRESERVE_TIMED_MESSAGE_ORDER,
 	//Timed Systems
 	RT_MAUDE, TTS, COMPACT_DTG,
 	

--- a/src/main/java/org/rebecalang/rmc/RMC.java
+++ b/src/main/java/org/rebecalang/rmc/RMC.java
@@ -77,6 +77,7 @@ public class RMC {
 			options.addOption(new Option("debug", "Enable debug mode in result C++ files."));
 			options.addOption(new Option("debug2", "Enable debug level 2 mode in result C++ files."));
 			options.addOption(new Option("h", "help", false, "Print this message."));
+			options.addOption(new Option("ptmo", "preserve-timed-message-order", false, "Preserve to order of messages in TimedRebeca."));
 
 			for (OptionGroup additionalOption : GenerateFiles.getInstance().getOptions())
 				options.addOptionGroup(additionalOption);

--- a/src/main/java/org/rebecalang/rmc/corerebeca/CoreRebecaFileGenerator.java
+++ b/src/main/java/org/rebecalang/rmc/corerebeca/CoreRebecaFileGenerator.java
@@ -103,6 +103,10 @@ public class CoreRebecaFileGenerator extends AbstractFileGenerator {
 			aFeatures.add(AnalysisFeature.EXPORT_STATE_SPACE);
 		}
 
+		if (commandLine.hasOption("ptmo")) {
+			aFeatures.add(AnalysisFeature.PRESERVE_TIMED_MESSAGE_ORDER);
+		}
+
 		analysisFeaturesNames = getFeaturesNames(aFeatures);
 
 		// Initialize Velocity Library.

--- a/src/main/java/org/rebecalang/rmc/timedrebeca/translator/TermPrimaryExpressionTranslator.java
+++ b/src/main/java/org/rebecalang/rmc/timedrebeca/translator/TermPrimaryExpressionTranslator.java
@@ -56,7 +56,8 @@ public class TermPrimaryExpressionTranslator extends org.rebecalang.rmc.corerebe
 				return retValue;
 			} else
 				return "_ref_now += " + 
-				StatementTranslatorContainer.translate(termPrimary.getParentSuffixPrimary().getArguments().get(0), "");
+				StatementTranslatorContainer.translate(termPrimary.getParentSuffixPrimary().getArguments().get(0), "") + ";\n" +
+						"_ref_last_processing_time += " +  StatementTranslatorContainer.translate(termPrimary.getParentSuffixPrimary().getArguments().get(0), "");
 		} else {
 			if (termPrimary.getParentSuffixPrimary() == null &&
 					termPrimary.getLabel() == CoreRebecaLabelUtility.LOCAL_VARIABLE &&

--- a/src/main/resources/vtl/timedrebeca/actor/AbstractTimedActorCPPTemplate.vm
+++ b/src/main/resources/vtl/timedrebeca/actor/AbstractTimedActorCPPTemplate.vm
@@ -39,6 +39,10 @@ TIME_TYPE AbstractTimedActor::getNow() {
     return this->_ref_now;
 }
 
+TIME_TYPE AbstractTimedActor::lastProcessingTime() {
+    return this->_ref_last_processing_time;
+}
+
 void AbstractTimedActor::addTimedBundles(byte senderId, TIME_TYPE executionTime, TIME_TYPE deadline) {
     timeEnqueue(this->executionTime, executionTime);
     timeEnqueue(this->deadline, deadline);
@@ -95,6 +99,7 @@ long AbstractTimedActor::execute() {
 	_ref_currentMessageArrival = executionTime[0];
 	_ref_currentMessageDeadline = deadline[0];
 	_ref_currentMessageWaitingTime = _ref_now - _ref_currentMessageArrival;
+	_ref_last_processing_time = 0;
 }
 
 void AbstractTimedActor::exportStateInXML(ostream &out, string tab) {

--- a/src/main/resources/vtl/timedrebeca/actor/AbstractTimedActorHeaderTemplate.vm
+++ b/src/main/resources/vtl/timedrebeca/actor/AbstractTimedActorHeaderTemplate.vm
@@ -26,6 +26,7 @@ public:
     virtual ~AbstractTimedActor();
     void setNow(TIME_TYPE now);
     TIME_TYPE getNow();
+    TIME_TYPE lastProcessingTime();
 
     #ifdef TTS
         int __pc;
@@ -35,6 +36,7 @@ public:
     TIME_TYPE* executionTime;
     TIME_TYPE* deadline;
     TIME_TYPE _ref_now;
+    TIME_TYPE _ref_last_processing_time;
     
     virtual long execute();
     

--- a/src/main/resources/vtl/timedrebeca/analyzer/AbstractTimedRebecaAnalyzerCPPTemplate.vm
+++ b/src/main/resources/vtl/timedrebeca/analyzer/AbstractTimedRebecaAnalyzerCPPTemplate.vm
@@ -128,7 +128,12 @@ int AbstractTimedRebecaAnalyzer::getNumberOfAlternatives(int rebecId, TIME_TYPE 
 	int numberOfAlternatives = 1;
     while((numberOfAlternatives < rebecs[rebecId]->maxQueueLength) &&
     		(rebecs[rebecId]->messageQueue[numberOfAlternatives]) &&
-    		(max(rebecs[rebecId]->getNow(), rebecs[rebecId]->executionTime[numberOfAlternatives])) == executionTime) {
+    		(max(rebecs[rebecId]->getNow(), rebecs[rebecId]->executionTime[numberOfAlternatives])) == executionTime
+#ifdef PRESERVE_TIMED_MESSAGE_ORDER
+            && rebecs[rebecId]->executionTime[numberOfAlternatives] == rebecs[rebecId]->executionTime[numberOfAlternatives-1]
+#endif
+
+    		) {
     	numberOfAlternatives++;
     }
     return numberOfAlternatives;

--- a/src/main/resources/vtl/timedrebeca/analyzer/AbstractTimedRebecaAnalyzerCPPTemplate.vm
+++ b/src/main/resources/vtl/timedrebeca/analyzer/AbstractTimedRebecaAnalyzerCPPTemplate.vm
@@ -206,10 +206,10 @@ void AbstractTimedRebecaAnalyzer::exportState(OpenBorderNode &current, ostream& 
 }
 
 void AbstractTimedRebecaAnalyzer::exportTransition(OpenBorderNode &source, OpenBorderNode &destination, 
-		string owner, string label, TIME_TYPE executionTime, TIME_TYPE shift, ostream& outStream) {
+		string owner, string label, TIME_TYPE executionTime, TIME_TYPE processingTime, TIME_TYPE shift, ostream& outStream) {
     outStream << "<transition source=\"" << source.state->stateID << "_" << 
 		(int)source.stateActiveBundleNumber << "\" destination=\"" << 
 		destination.state->stateID << "_" << (int)destination.stateActiveBundleNumber <<
-    	"\" executionTime=\"" << (int)executionTime << "\" shift=\"" << (int) shift << "\"> <messageserver owner=\"" << 
+    	"\" executionTime=\"" << (int)executionTime << "\" processingTime=\"" << (int)processingTime << "\" shift=\"" << (int) shift << "\"> <messageserver owner=\"" <<
     	owner << "\" title=\"" << label << "\"/></transition>" << endl;
 }

--- a/src/main/resources/vtl/timedrebeca/analyzer/AbstractTimedRebecaAnalyzerHeaderTemplate.vm
+++ b/src/main/resources/vtl/timedrebeca/analyzer/AbstractTimedRebecaAnalyzerHeaderTemplate.vm
@@ -48,7 +48,7 @@ protected:
 
 	virtual void exportState(OpenBorderNode &current, ostream& outStream);
 	virtual void exportTransition(OpenBorderNode &source, OpenBorderNode &destination, 
-		string owner, string label, TIME_TYPE executionTime, TIME_TYPE shift, ostream& outStream);
+		string owner, string label, TIME_TYPE executionTime, TIME_TYPE processingTime, TIME_TYPE shift, ostream& outStream);
 
 	OpenBorderNode storeRecentlyCreatedState(byte &result, TIME_TYPE &shift,
 		TimedBFSState *parent, int parentBundleIndex, int executedRebecIndex);

--- a/src/main/resources/vtl/timedrebeca/analyzer/FTTSPatchTemplate.vm
+++ b/src/main/resources/vtl/timedrebeca/analyzer/FTTSPatchTemplate.vm
@@ -23,7 +23,7 @@ void TimedModelChecker::printCounterExampleTransition(TimedBFSState* parent, Tim
 	int rebecId = child->parents.front().executedRebecIndex;
 	string label = "";
 	label = rebecs[rebecId]->activeAction();
-	exportTransition(parentNode, childNode, rebecs[rebecId]->getName(), label, rebecs[rebecId]->getNow(), 0, out);
+	exportTransition(parentNode, childNode, rebecs[rebecId]->getName(), label, rebecs[rebecId]->getNow(), rebecs[rebecId]->lastProcessingTime(), 0, out);
 }
 void TimedModelChecker::printModelCheckingOptions() {
     out << "\t<option>FTTS</option>" << std::endl;
@@ -161,7 +161,8 @@ long TimedModelChecker::executeRebec(int rebecId) {
     }
     #ifdef EXPORT_STATE_SPACE
     string label = actionName;
-    exportTransition(current, newState, rebecs[rebecId]->getName(), label, executionTime, shift, statespace);
+    TIME_TYPE lastProcessingTime = rebecs[rebecId]->lastProcessingTime();
+    exportTransition(current, newState, rebecs[rebecId]->getName(), label, executionTime, lastProcessingTime, shift, statespace);
 	#endif
     return nonDetTrans;
 }


### PR DESCRIPTION
Currently, in TimedRebeca alternatives are generared for messages in the queue that arrived prior to the current now. Hence, the order of the messages is not preserved. For one of my applications I need a preserved order of messages.

I added an option that only messages that arrived at the same time are alternatives.
